### PR TITLE
fix: Security scan and E2E test pipeline issues

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -339,6 +339,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      security-events: write
     
     steps:
     - name: Checkout code
@@ -352,7 +355,7 @@ jobs:
         output: 'trivy-results.sarif'
         
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
@@ -374,9 +377,11 @@ jobs:
         WITH_COVERAGE: false
         PYTEST_MARKERS: e2e
       run: |
+        # Build all images first to ensure they exist
+        docker compose -f docker-compose.test.yml build
+        
         # Run full stack E2E tests
         docker compose -f docker-compose.test.yml up \
-          --build \
           --abort-on-container-exit \
           --exit-code-from test-runner \
           test-runner


### PR DESCRIPTION
## Security Fixes
- ✅ **Upgrade CodeQL action**: v2 → v3 (resolves deprecation warning)
- ✅ **Add security-events permission**: Enables SARIF upload for security scanning

## E2E Test Fixes  
- ✅ **Add explicit build step**: Ensures Docker images exist before E2E tests
- ✅ **Remove redundant --build flag**: Prevents build conflicts

## Issue Resolution
- **Security**: `CodeQL Action major versions v1 and v2 have been deprecated`
- **E2E**: `No such image: fae-knowledge-base-ingest:latest`

This ensures the complete enterprise pipeline works with:
🔒 Working security vulnerability scanning
🧪 Functional end-to-end testing
🚀 Ready for production deployment