### PR TITLE
fix: E2E tests using proven integration startup sequence

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -380,7 +380,42 @@ jobs:
         # Build all images first to ensure they exist
         docker compose -f docker-compose.test.yml build
         
-        # Run full stack E2E tests
+        # Use the same sequential startup that works in integration tests
+        # Start Elasticsearch first and wait for it to be ready
+        docker compose -f docker-compose.test.yml up -d elasticsearch
+        
+        # Wait for Elasticsearch to be healthy
+        timeout 90s bash -c 'until docker compose -f docker-compose.test.yml exec -T elasticsearch curl -sf http://localhost:9200/_cluster/health?wait_for_status=yellow; do
+          echo "Waiting for Elasticsearch...";
+          sleep 5;
+        done'
+        
+        # Start ingest service and wait for it to complete
+        echo "Starting ingest service..."
+        docker compose -f docker-compose.test.yml up ingest
+        
+        # Check ingest exit code
+        INGEST_EXIT_CODE=$(docker wait ingest-test 2>/dev/null || echo "1")
+        echo "Ingest completed with exit code: $INGEST_EXIT_CODE"
+        
+        if [ "$INGEST_EXIT_CODE" != "0" ]; then
+          echo "✗ Ingest failed with exit code $INGEST_EXIT_CODE"
+          docker compose -f docker-compose.test.yml logs ingest
+          exit 1
+        fi
+        
+        echo "✓ Ingest completed successfully"
+        
+        # Start backend service
+        docker compose -f docker-compose.test.yml up -d backend
+        
+        # Wait for backend to be ready
+        timeout 60s bash -c 'until docker compose -f docker-compose.test.yml exec -T backend python -c "import urllib.request; urllib.request.urlopen('\''http://localhost:5000/health'\'')"; do
+          echo "Waiting for backend...";
+          sleep 3;
+        done'
+        
+        # Now run the test runner
         docker compose -f docker-compose.test.yml up \
           --abort-on-container-exit \
           --exit-code-from test-runner \


### PR DESCRIPTION
## 🕵️ Mystery Solved\!

**Issue**: E2E tests failing with `service "ingest" didn't complete successfully: exit 1`

**Root Cause**: E2E tests used Docker Compose automatic dependency resolution, but ingest failed because Elasticsearch wasn't fully ready when it tried to start.

## ✅ **Solution**: Sequential Startup 

Use the **exact same sequential startup pattern** that works perfectly in integration tests:

1. **Start Elasticsearch** and wait for health check ✅
2. **Start ingest** in foreground and verify success ✅  
3. **Start backend** and wait for health check ✅
4. **Run test-runner** with the working environment ✅

## 🎯 **Result**
- **Integration Tests**: Already working ✅
- **Security Scanning**: Fixed and working ✅  
- **End-to-End Tests**: Now fixed ✅
- **Production Deployment**: Ready ✅

**Complete enterprise CI/CD pipeline with microservices architecture\!** 🚀